### PR TITLE
Add redirect to Google sign-in

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -60,6 +60,7 @@ export const useAuth = () => {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
+        redirectTo: window.location.origin,
         queryParams: {
           prompt: opts?.promptSelectAccount ? "select_account" : undefined,
         },


### PR DESCRIPTION
## Summary
- ensure Supabase OAuth with Google redirects back to the site

## Testing
- `npm ci`
- `npm run lint` *(fails: cannot pass linter)*

------
https://chatgpt.com/codex/tasks/task_e_68501a5484fc832ebac6bdbe7e35af55