### PR TITLE
Enable Ask AI via OpenAI edge function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Rename this file to `.env` and fill in your credentials
+# OpenAI API key for edge functions
+OPENAI_API_KEY=
+# OpenAI API key for client calls (not used directly but kept for reference)
+VITE_OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Environment variables
+
+To enable the Ask AI feature, create a `.env` file in the project root based on `.env.example` and provide your OpenAI API key:
+
+```sh
+cp .env.example .env
+echo "OPENAI_API_KEY=your-key" >> .env
+```
+
+The same key is used by the Supabase edge function that communicates with OpenAI.

--- a/supabase/functions/ask-ai/index.ts
+++ b/supabase/functions/ask-ai/index.ts
@@ -1,0 +1,57 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+const openAIApiKey = Deno.env.get("OPENAI_API_KEY");
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { question } = await req.json();
+
+    if (!question) {
+      return new Response(JSON.stringify({ error: "Missing question" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const aiResponse = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${openAIApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "You are a helpful assistant for a mindfulness app." },
+          { role: "user", content: question },
+        ],
+        temperature: 0.7,
+        max_tokens: 200,
+      }),
+    });
+
+    const aiData = await aiResponse.json();
+    const answer = aiData.choices?.[0]?.message?.content?.trim() || "No response.";
+
+    return new Response(JSON.stringify({ answer }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    console.error("ask-ai error:", e);
+    return new Response(JSON.stringify({ error: "Error contacting AI." }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add new Supabase function `ask-ai` that proxies questions to OpenAI
- update AskAI page to call the edge function
- document OpenAI environment variable setup
- ignore `.env` files and provide `.env.example`

## Testing
- `npm run lint` *(fails: 12 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68502c9b83c8832e84fd67b494d8f094