### PR TITLE
Add API key check for ask-ai

### DIFF
--- a/supabase/functions/ask-ai/index.ts
+++ b/supabase/functions/ask-ai/index.ts
@@ -1,0 +1,69 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+const openAIApiKey = Deno.env.get("OPENAI_API_KEY");
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { question } = await req.json();
+
+    if (!openAIApiKey) {
+      console.error("OpenAI API key not set");
+      return new Response(
+        JSON.stringify({ error: "Missing OpenAI API key" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const aiResponse = await fetch(
+      "https://api.openai.com/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${openAIApiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "gpt-4o-mini",
+          messages: [
+            {
+              role: "system",
+              content: "You are a helpful assistant for a mindfulness app.",
+            },
+            { role: "user", content: question },
+          ],
+          temperature: 0.7,
+          max_tokens: 200,
+        }),
+      },
+    );
+
+    const aiData = await aiResponse.json();
+    const answer =
+      aiData.choices?.[0]?.message?.content?.trim() || "No response.";
+
+    return new Response(JSON.stringify({ answer }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    console.error("ask-ai error:", e);
+    return new Response(JSON.stringify({ error: "Error contacting AI." }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add new ask-ai function to Supabase
- check for the `OPENAI_API_KEY` and return a clear error when missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850304f10bc832e9d39c27cfd4745e5