### PR TITLE
Add env example and README setup note

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for local development with Vite
+# Copy this file to `.env` and replace the placeholder values.
+
+VITE_SUPABASE_URL="your-supabase-url"
+VITE_SUPABASE_ANON_KEY="your-anon-key"
+VITE_OPENAI_API_KEY="your-openai-api-key"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: Copy the example environment file and update the values.
+cp .env.example .env
+# Edit `.env` and replace the placeholder values with your credentials.
+
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- include a `.env.example` file with placeholder environment variables
- update README instructions to copy the example env file before running the dev server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' at first, then runs with warnings and errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68526aef7da8832e8e77ecdd592a7478