### PR TITLE
Fix nav route for Sounds and improve Lumina chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ const App = () => (
           <Route path="/yoga" element={<Yoga />} />
           <Route path="/ask-ai" element={<AskAI />} />
           <Route path="/sounds" element={<Sounds />} />
+          {/* Temporary alias for older links */}
+          <Route path="/sleep" element={<Sounds />} />
           <Route path="/discover" element={<Discover />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/premium" element={<Premium />} />

--- a/src/pages/AskAI.tsx
+++ b/src/pages/AskAI.tsx
@@ -59,10 +59,14 @@ const AskAI = () => {
       });
       
       // Add error message to conversation
-      setConversation([...newConversation, { 
-        role: "assistant", 
-        content: "I apologize, but I'm experiencing some technical difficulties. Please try asking your question again in a moment." 
-      }]);
+        setConversation([
+          ...newConversation,
+          {
+            role: "assistant",
+            content:
+              "Hmm, I'm having trouble responding right now. Please try again later."
+          }
+        ]);
     } finally {
       setIsLoading(false);
     }
@@ -132,17 +136,22 @@ const AskAI = () => {
           </div>
 
           {/* Chat Interface */}
-          <div className="space-y-4 mb-6 max-h-96 overflow-y-auto">
+          <div className="flex flex-col space-y-3 mb-6 max-h-96 overflow-y-auto">
             {conversation.map((msg, index) => (
-              <div key={index} className="calm-card p-4">
-                <p className="text-black">
-                  {msg.content}
-                </p>
+              <div
+                key={index}
+                className={`rounded-lg p-3 max-w-[75%] ${
+                  msg.role === "user"
+                    ? "self-end bg-calm-purple text-white"
+                    : "self-start bg-white/20 text-white"
+                }`}
+              >
+                {msg.content}
               </div>
             ))}
             {isLoading && (
-              <div className="calm-card p-4">
-                <p className="text-black">Lumina is thinking...</p>
+              <div className="self-start rounded-lg p-3 bg-white/20 text-white max-w-[75%]">
+                Lumina is thinking...
               </div>
             )}
           </div>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Plus, Heart, MessageCircle, Share2, Star, Trophy, Award } from "lucide-react";
+import { ArrowLeft, Plus, Heart, MessageCircle, Share2, Star, Trophy, Award, Volume2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 
@@ -86,8 +86,8 @@ const Community = () => {
     navigate("/dashboard");
   };
 
-  const handleSleep = () => {
-    navigate("/sleep");
+  const handleSounds = () => {
+    navigate("/sounds");
   };
 
   const handleDiscover = () => {
@@ -288,12 +288,14 @@ const Community = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={handleSleep}
+            onClick={handleSounds}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div 
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -1,6 +1,6 @@
 
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Search, Sparkles, BookOpen, Music, Heart, TrendingUp, Brain, Leaf } from "lucide-react";
+import { ArrowLeft, Search, Sparkles, BookOpen, Music, Heart, TrendingUp, Brain, Leaf, Volume2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const Discover = () => {
@@ -38,8 +38,8 @@ const Discover = () => {
     navigate("/dashboard");
   };
 
-  const handleSleep = () => {
-    navigate("/sleep");
+  const handleSounds = () => {
+    navigate("/sounds");
   };
 
   const handleCommunity = () => {
@@ -179,12 +179,14 @@ const Discover = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={() => navigate("/sleep")}
+            onClick={handleSounds}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div className="flex flex-col items-center space-y-1 min-w-0 flex-1">
             <div className="w-6 h-6 bg-white rounded-full flex items-center justify-center">🔍</div>

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,6 +1,6 @@
 
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Trophy, Star, Crown, Award, Heart, MessageCircle } from "lucide-react";
+import { ArrowLeft, Trophy, Star, Crown, Award, Heart, MessageCircle, Volume2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const Leaderboard = () => {
@@ -107,8 +107,8 @@ const Leaderboard = () => {
     navigate("/dashboard");
   };
 
-  const handleSleep = () => {
-    navigate("/sleep");
+  const handleSounds = () => {
+    navigate("/sounds");
   };
 
   const handleDiscover = () => {
@@ -288,12 +288,14 @@ const Leaderboard = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={handleSleep}
+            onClick={handleSounds}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div 
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"

--- a/src/pages/Meditate.tsx
+++ b/src/pages/Meditate.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Volume2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -208,12 +208,14 @@ const Meditate = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={() => navigate("/sleep")}
+            onClick={() => navigate("/sounds")}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div 
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"

--- a/src/pages/Premium.tsx
+++ b/src/pages/Premium.tsx
@@ -1,6 +1,6 @@
 
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Crown, Star, Check, Sparkles } from "lucide-react";
+import { ArrowLeft, Crown, Star, Check, Sparkles, Volume2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const Premium = () => {
@@ -37,8 +37,8 @@ const Premium = () => {
     navigate("/dashboard");
   };
 
-  const handleSleep = () => {
-    navigate("/sleep");
+  const handleSounds = () => {
+    navigate("/sounds");
   };
 
   const handleDiscover = () => {
@@ -200,12 +200,14 @@ const Premium = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={() => navigate("/sleep")}
+            onClick={handleSounds}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div 
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, User, Settings, Award, Calendar, Clock, Heart } from "lucide-react";
+import { ArrowLeft, User, Settings, Award, Calendar, Clock, Heart, Volume2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -29,8 +29,8 @@ const Profile = () => {
     navigate("/dashboard");
   };
 
-  const handleSleep = () => {
-    navigate("/sleep");
+  const handleSounds = () => {
+    navigate("/sounds");
   };
 
   const handleDiscover = () => {
@@ -173,12 +173,14 @@ const Profile = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={handleSleep}
+            onClick={handleSounds}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div 
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"

--- a/src/pages/Yoga.tsx
+++ b/src/pages/Yoga.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "@/hooks/useAuth";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Volume2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -213,12 +213,14 @@ const Yoga = () => {
             </div>
             <span className="text-white/60 text-xs">Home</span>
           </div>
-          <div 
+          <div
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"
-            onClick={() => navigate("/sleep")}
+            onClick={() => navigate("/sounds")}
           >
-            <div className="w-6 h-6 text-white/60 flex items-center justify-center">🌙</div>
-            <span className="text-white/60 text-xs">Sleep</span>
+            <div className="w-6 h-6 text-white/60 flex items-center justify-center">
+              <Volume2 className="w-4 h-4 text-white/60" />
+            </div>
+            <span className="text-white/60 text-xs">Sounds</span>
           </div>
           <div 
             className="flex flex-col items-center space-y-1 min-w-0 flex-1 cursor-pointer"


### PR DESCRIPTION
## Summary
- keep `/sounds` available across the site and alias `/sleep` to it
- make Lumina chat messages display in a bubble layout
- update error message to avoid repeated apologies
- swap all navigation links from Sleep to Sounds

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685669c18ccc832ebfbacda0b44a4582