### PR TITLE
Persist chat history for Ask AI

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -70,6 +70,59 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      },
+      conversations: {
+        Row: {
+          id: string
+          user_id: string
+          title: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          title?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          title?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      },
+      conversation_messages: {
+        Row: {
+          id: string
+          conversation_id: string
+          role: string
+          content: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          conversation_id: string
+          role: string
+          content: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          conversation_id?: string
+          role?: string
+          content?: string
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "conversation_messages_conversation_id_fkey"
+            columns: ["conversation_id"]
+            isOneToOne: false
+            referencedRelation: "conversations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {

--- a/supabase/migrations/20250622065351-chat-history.sql
+++ b/supabase/migrations/20250622065351-chat-history.sql
@@ -1,0 +1,46 @@
+-- Add conversations table
+CREATE TABLE IF NOT EXISTS public.conversations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  title TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Each conversation belongs to a user
+ALTER TABLE public.conversations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own conversations" ON public.conversations
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own conversations" ON public.conversations
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own conversations" ON public.conversations
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own conversations" ON public.conversations
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Chat messages table
+CREATE TABLE IF NOT EXISTS public.conversation_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.conversation_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own conversation messages" ON public.conversation_messages
+  FOR SELECT USING (auth.uid() = (SELECT user_id FROM public.conversations c WHERE c.id = conversation_messages.conversation_id));
+
+CREATE POLICY "Users can insert their own conversation messages" ON public.conversation_messages
+  FOR INSERT WITH CHECK (auth.uid() = (SELECT user_id FROM public.conversations c WHERE c.id = conversation_id));
+
+CREATE POLICY "Users can update their own conversation messages" ON public.conversation_messages
+  FOR UPDATE USING (auth.uid() = (SELECT user_id FROM public.conversations c WHERE c.id = conversation_messages.conversation_id));
+
+CREATE POLICY "Users can delete their own conversation messages" ON public.conversation_messages
+  FOR DELETE USING (auth.uid() = (SELECT user_id FROM public.conversations c WHERE c.id = conversation_messages.conversation_id));
+


### PR DESCRIPTION
## Summary
- add migrations for conversations and messages tables with RLS policies
- extend supabase types to include new tables
- update Ask AI page to store and retrieve conversations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857a8389394832ea56d5cae54e18f88